### PR TITLE
product service - swagger 추가 

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -32,15 +32,16 @@ repositories {
 }
 
 dependencies {
+    // springboot web initial setting
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation name: 'commonlib', version: '0.7', ext: 'jar'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // eureka
 // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-eureka-client
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-eureka-client', version: '4.1.3'
 
@@ -49,10 +50,25 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // mapstruct
-    implementation("org.mapstruct:mapstruct:1.5.5.Final")
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     kapt 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // library
+    implementation name: 'commonlib', version: '0.7', ext: 'jar'
+
+    // openapi
+    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+    implementation 'org.springdoc:springdoc-openapi-kotlin:1.7.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.2.0'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // logging
+    implementation("io.github.oshai:kotlin-logging-jvm:6.0.9")
 }
 
 kotlin {

--- a/product-service/src/main/kotlin/org/wine/productservice/config/OpenApiConfig.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/config/OpenApiConfig.kt
@@ -1,0 +1,20 @@
+package org.wine.productservice.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+    @Bean
+    fun openAPI(): OpenAPI = OpenAPI()
+        .components(Components())
+        .info(apiInfo())
+
+    private fun apiInfo() = Info()
+        .title("winemall - product service api")
+        .description("winemall의 product service api 입니다.")
+        .version("1.0.0")
+}

--- a/product-service/src/main/kotlin/org/wine/productservice/config/WineApiSpec.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/config/WineApiSpec.kt
@@ -1,0 +1,163 @@
+package org.wine.productservice.config
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import org.wine.productservice.wine.dto.*
+
+open class ApiResponseSuccess<T> {
+    @field:Schema(example = "200")
+    val status: Int = 0
+
+    @field:Schema(example = "Success")
+    val message: String = ""
+
+    val data: T? = null
+}
+
+open class ApiResponseCreated<T> {
+    @field:Schema(example = "201")
+    val status: Int = 0
+
+    @field:Schema(example = "Created")
+    val message: String = ""
+
+    val data: T? = null
+}
+
+open class ApiResponseBadRequest {
+    @field:Schema(example = "400")
+    val status: Int = 0
+
+    @field:Schema(example = "Bad Request")
+    val message: String = ""
+}
+
+open class ApiResponseServerError {
+    @field:Schema(example = "500")
+    val status: Int = 0
+
+    @field:Schema(example = "Internal Server Error")
+    val message: String = ""
+}
+
+class GetWines200: ApiResponseSuccess<WinesResponse>()
+class CreateWine201: ApiResponseCreated<WineResponse>()
+class UpdateWine200: ApiResponseCreated<WineResponse>()
+
+object WineApiSpec {
+    @Target(AnnotationTarget.FUNCTION)
+    @Retention(AnnotationRetention.RUNTIME)
+    @Operation(
+        summary = "와인 목록 조회",
+        description = "와인 목록을 조회합니다.",
+        responses = [
+            SwaggerApiResponse(
+                responseCode = "200",
+                description = "와인 목록 조회 성공",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = GetWines200::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "500",
+                description = "서버 에러",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ApiResponseServerError::class))]
+            ),
+        ]
+    )
+    annotation class GetWines
+
+    @Target(AnnotationTarget.FUNCTION)
+    @Retention(AnnotationRetention.RUNTIME)
+    @Operation(
+        summary = "와인 생성",
+        description = "와인을 생성합니다.",
+        requestBody = RequestBody(
+            description = "와인 생성 요청 데이터",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = WineCreateRequestDto::class)
+                )
+            ]
+        ),
+        responses = [
+            SwaggerApiResponse(
+                responseCode = "200",
+                description = "와인 생성 성공 후 생성된 와인 정보 반환",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = CreateWine201::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = """
+                    잘못된 요청. 다음과 같은 경우 발생할 수 있습니다.   
+                    - 지역을 찾을 수 없음 : Invalid region id : {id}
+                    - 카테고리를 찾을 수 없음 : Invalid category ids : {ids}
+                    - 잘못된 와인 이름 : Name must be between 2 and 100 characters long
+                    - 잘못된 와인 설명 : Description must be at most 500 characters long 
+                    - 잘못된 지역 ID : RegionId must be a positive number
+                    - 잘못된 알콜 도수 : Alcohol percentage must be greater than 0 또는 Alcohol percentage must be less than or equal to 100
+                    - 잘못된 카테고리 ID 목록 : At most 5 categories can be tagged
+                """,
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ApiResponseBadRequest::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "500",
+                description = "서버 에러",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ApiResponseServerError::class))]
+            ),
+        ]
+    )
+    annotation class CreateWine
+
+
+    @Target(AnnotationTarget.FUNCTION)
+    @Retention(AnnotationRetention.RUNTIME)
+    @Operation(
+        summary = "와인 수정",
+        description = "와인 정보를 수정합니다.",
+        requestBody = RequestBody(
+            description = "와인 수정 요청 데이터(수정할 데이터만 담아서 요청.)",
+            required = true,
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = WineUpdateRequestDto::class)
+                )
+            ]
+        ),
+        responses = [
+            SwaggerApiResponse(
+                responseCode = "200",
+                description = "와인 수정 성공 후 생성된 와인 정보 반환",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = UpdateWine200::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = """
+                    잘못된 요청. 다음과 같은 경우 발생할 수 있습니다.   
+                    - 지역을 찾을 수 없음 : Invalid region id : {id}
+                    - 카테고리를 찾을 수 없음 : Invalid category ids : {ids}
+                    - 잘못된 와인 이름 :
+                        - Name cannot be blank
+                        - Name must be between 2 and 100 characters long
+                    - 잘못된 와인 설명 :
+                        - Description cannot be blank
+                        - Description must be at most 500 characters long 
+                    - 잘못된 지역 ID : RegionId must be a positive number
+                    - 잘못된 알콜 도수 : Alcohol percentage must be greater than 0 또는 Alcohol percentage must be less than or equal to 100
+                    - 잘못된 카테고리 ID 목록 : At most 5 categories can be tagged
+                """,
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ApiResponseBadRequest::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "500",
+                description = "서버 에러",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ApiResponseServerError::class))]
+            ),
+        ]
+    )
+    annotation class UpdateWine
+}

--- a/product-service/src/main/kotlin/org/wine/productservice/exception/GlobalExceptionHandler.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/exception/GlobalExceptionHandler.kt
@@ -1,15 +1,22 @@
 package org.wine.productservice.exception
 
+import com.sun.jdi.request.InvalidRequestStateException
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.wine.productservice.wine.exception.UnauthorizedException
 
+private val logger = KotlinLogging.logger {}
+
 open class NotFoundException(message: String) : RuntimeException(message)
+open class BadRequestException(message: String) : RuntimeException(message)
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
+    @ExceptionHandler(UnauthorizedException::class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     fun handleUnauthorizedException(ex: UnauthorizedException): Map<String, Any> {
         return mapOf("error" to "Unauthorized", "message" to ex.message.orEmpty())
@@ -18,6 +25,35 @@ class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException::class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     fun handleNotFoundException(ex: NotFoundException): ApiResponse.Error {
+        logger.debug { "Not found: ${ex.message}" }
         return ApiResponse.Error(status = 404, message = ex.message ?: "Resource not found")
+    }
+
+    @ExceptionHandler(BadRequestException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleBadRequestException(ex: BadRequestException): ApiResponse.Error {
+        logger.debug { "Bad request: ${ex.message}" }
+        return ApiResponse.Error(status = 400, message = ex.message ?: "Bad request")
+    }
+
+    @ExceptionHandler(InvalidRequestStateException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleGenericException(ex: InvalidRequestStateException): ApiResponse.Error {
+        return ApiResponse.Error(status = 400, message = ex.message ?: "Bad request")
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleValidationExceptions(ex: MethodArgumentNotValidException): ApiResponse.Error {
+        val errors = ex.bindingResult.fieldErrors.map { "${it.field}: ${it.defaultMessage}" }
+        logger.debug { "Validation failed: $errors" }
+        return ApiResponse.Error(status = 400, message = "Validation failed $errors")
+    }
+
+    @ExceptionHandler(Exception::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handleGenericException(ex: Exception): ApiResponse.Error {
+        logger.error { "Unhandled exception occurred : ${ex.message}"}
+        return ApiResponse.Error(status = 500, message = "Internal Server Error")
     }
 }

--- a/product-service/src/main/kotlin/org/wine/productservice/wine/controller/WineController.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/wine/controller/WineController.kt
@@ -1,12 +1,14 @@
 package org.wine.productservice.product.controller
 
 import ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.HttpHeaders
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import jwt.JwtTokenProvider
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -14,52 +16,41 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.wine.productservice.wine.dto.WineCreateRequestDto
-import org.wine.productservice.wine.dto.WineDto
-import org.wine.productservice.wine.dto.WineUpdateRequestDto
+import org.wine.productservice.config.WineApiSpec
+import org.wine.productservice.wine.dto.*
 import org.wine.productservice.wine.service.WineService
-
 
 @RestController
 @RequestMapping("/api/wines")
+@Tag(name = "Wine", description = "와인 API")
 class WineController @Autowired constructor(
     private val wineService: WineService,
 ){
     @GetMapping("/health")
+    @Operation(summary = "Health Check", description = "서버 상태 확인")
     fun health(): String {
         return "ok";
     }
 
     @PostMapping("/v1")
-    fun createWine(@RequestBody requestDto: WineCreateRequestDto): ResponseEntity<ApiResponse<Any>> {
+    @WineApiSpec.CreateWine
+    fun createWine(@Valid @RequestBody requestDto: WineCreateRequestDto): ResponseEntity<ApiResponse<Any>> {
         val wine = wineService.addWine(requestDto)
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ApiResponse.Success(status = 201, message = "Created", data = mapOf("wine" to wine)))
+            .body(ApiResponse.Success(status = 201, message = "Created", data = WineResponse(wine)))
     }
 
     @GetMapping("/v1")
+    @WineApiSpec.GetWines
     fun getWines(@RequestHeader headers: HttpHeaders): ResponseEntity<ApiResponse<Any>> {
-        val wines: List<WineDto>? = wineService.getWinesForSeller()
-        return ResponseEntity.ok(ApiResponse.Success(status = 200, message = "Success", data = mapOf("wines" to wines)))
+        val wines: List<WineDto> = wineService.getWinesForSeller()
+        return ResponseEntity.ok(ApiResponse.Success(status = 200, message = "Success", data = WinesResponse(wines)))
     }
 
     @PatchMapping("/v1/{wineId}")
-    fun updateWine(@PathVariable wineId: Long, @RequestBody requestDto: WineUpdateRequestDto): ResponseEntity<ApiResponse<Any>> {
+    @WineApiSpec.UpdateWine
+    fun updateWine(@Valid @PathVariable wineId: Long, @RequestBody requestDto: WineUpdateRequestDto): ResponseEntity<ApiResponse<Any>> {
         val wine = wineService.updateWine(wineId, requestDto)
         return ResponseEntity.ok(ApiResponse.Success(status = 200, message = "Success", data = mapOf("wine" to wine)))
-    }
-
-    @GetMapping("/test/v1")
-    fun getTest(@RequestHeader headers: HttpHeaders): String {
-        val jwtTokenProvider = JwtTokenProvider()
-        val authorizationHeader = headers.getFirst(HttpHeaders.AUTHORIZATION)
-
-        return if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            val jwt = authorizationHeader.substring(7) // "Bearer " 이후의 JWT 부분 추출
-            "JWT is present: ${jwtTokenProvider.getAccount(jwt).toString()}"
-        } else {
-            "JWT is not present"
-        }
-        return ""
     }
 }

--- a/product-service/src/main/kotlin/org/wine/productservice/wine/dto/CategoryDto.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/wine/dto/CategoryDto.kt
@@ -1,10 +1,13 @@
 package org.wine.productservice.wine.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
 import org.wine.productservice.wine.entity.Category
 import java.io.Serializable
 
 data class CategoryDto(
+    @field:Schema(description = "카테고리 ID", example = "1")
     val id: Long,
+    @field:Schema(description = "카테고리 이름", example = "카테고리이름")
     val name: String,
 ) : Serializable {
     companion object {

--- a/product-service/src/main/kotlin/org/wine/productservice/wine/dto/RegionDto.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/wine/dto/RegionDto.kt
@@ -1,11 +1,13 @@
 package org.wine.productservice.wine.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
 import org.wine.productservice.wine.entity.Region
 import java.io.Serializable
 
-
 data class RegionDto (
+    @field:Schema(description = "지역 ID", example = "1")
     val id: Long,
+    @field:Schema(description = "지역 이름", example = "region1")
     val name: String,
 ) : Serializable {
     companion object {

--- a/product-service/src/main/kotlin/org/wine/productservice/wine/dto/WineCreateRequestDto.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/wine/dto/WineCreateRequestDto.kt
@@ -1,28 +1,36 @@
 package org.wine.productservice.wine.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
 import jakarta.validation.constraints.*
 import java.io.Serializable
 import java.math.BigDecimal
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class WineCreateRequestDto(
-    @NotBlank(message ="Name is required")
-    @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters long")
+    @field:Schema(description = "와인 이름", example = "wine1")
+    @field:NotBlank(message = "Name is required")
+    @field:Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters long")
     val name: String,
 
-    @NotBlank(message = "Description is required")
-    @Size(max = 5000, message = "Description must be at most 500 characters long")
+    @field:Valid
+    @field:Schema(description = "와인 설명", example = "와인 설명")
+    @field:NotBlank(message = "Description is required")
+    @field:Size(max = 5000, message = "Description must be at most 500 characters long")
     val description: String,
 
-    @NotNull(message = "RegionId is required")
-    @Positive(message = "RegionId must be a positive number")
+    @field:Schema(description = "지역 ID", example = "1")
+    @field:NotNull(message = "RegionId is required")
+    @field:Positive(message = "RegionId must be a positive number")
     val regionId: Long,
 
-    @DecimalMin(value = "0.0", inclusive = false, message = "Alcohol percentage must be greater than 0")
-    @DecimalMax(value = "100.0", inclusive = true, message = "Alcohol percentage must be less than or equal to 100")
+    @field:Schema(description = "알콜 도수(0.0 <= x <= 100.0)", example = "12.5")
+    @field:DecimalMin(value = "0.0", inclusive = true, message = "Alcohol percentage must be greater than or equal to 0")
+    @field:DecimalMax(value = "100.0", inclusive = true, message = "Alcohol percentage must be less than or equal to 100")
     val alcoholPercentage: BigDecimal,
 
-    @Size(max = 5, message = "At most 5 categories can be tagged")
+    @field:Schema(description = "카테고리 ID 목록", example = "[1, 2, 3]")
+    @field:Size(max = 5, message = "At most 5 categories can be tagged")
     val categoryIds: Set<Long>?
 ) : Serializable

--- a/product-service/src/main/kotlin/org/wine/productservice/wine/dto/WineDto.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/wine/dto/WineDto.kt
@@ -1,15 +1,20 @@
 package org.wine.productservice.wine.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
 import org.wine.productservice.wine.entity.Wine
 import java.io.Serializable
 import java.math.BigDecimal
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class WineDto(
+    @field:Schema(description = "와인 ID", example = "1")
     val id: Long,
+    @field:Schema(description = "와인 이름", example = "와인이름")
     val name: String,
+    @field:Schema(description = "와인 설명", example = "와인 설명")
     val description: String,
+    @field:Schema(description = "알콜 도수", example = "12.5")
     val alcoholPercentage: BigDecimal,
     val region: RegionDto?,
     val categories: Set<CategoryDto>?,

--- a/product-service/src/main/kotlin/org/wine/productservice/wine/dto/WineResponse.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/wine/dto/WineResponse.kt
@@ -1,0 +1,4 @@
+package org.wine.productservice.wine.dto
+
+data class WineResponse(val wine: WineDto)
+data class WinesResponse(val wines: List<WineDto>)

--- a/product-service/src/main/kotlin/org/wine/productservice/wine/dto/WineUpdateRequestDto.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/wine/dto/WineUpdateRequestDto.kt
@@ -1,25 +1,31 @@
 package org.wine.productservice.wine.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.*
 import java.io.Serializable
 import java.math.BigDecimal
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class WineUpdateRequestDto(
-    @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters long")
+    @field:Schema(description = "와인 이름", example = "wine2")
+    @field:Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters long")
     val name: String?,
 
-    @Size(max = 5000, message = "Description must be at most 500 characters long")
+    @field:Schema(description = "와인 설명", example = "와인 설명 수정")
+    @field:Size(max = 5000, message = "Description must be at most 500 characters long")
     val description: String?,
 
-    @Positive(message = "RegionId must be a positive number")
+    @field:Schema(description = "지역 ID", example = "1")
+    @field:Positive(message = "RegionId must be a positive number")
     val regionId: Long?,
 
-    @DecimalMin(value = "0.0", inclusive = false, message = "Alcohol percentage must be greater than 0")
-    @DecimalMax(value = "100.0", inclusive = true, message = "Alcohol percentage must be less than or equal to 100")
+    @field:Schema(description = "알콜 도수(0.0 < x <= 100.0)", example = "15.0")
+    @field:DecimalMin(value = "0.0", inclusive = false, message = "Alcohol percentage must be greater than 0")
+    @field:DecimalMax(value = "100.0", inclusive = true, message = "Alcohol percentage must be less than or equal to 100")
     val alcoholPercentage: BigDecimal?,
 
-    @Size(max = 5, message = "At most 5 categories can be tagged")
+    @field:Schema(description = "카테고리 ID 목록", example = "[2]")
+    @field:Size(max = 5, message = "At most 5 categories can be tagged")
     val categoryIds: Set<Long>?
 ) : Serializable

--- a/product-service/src/main/kotlin/org/wine/productservice/wine/exception/BadRequestException.kt
+++ b/product-service/src/main/kotlin/org/wine/productservice/wine/exception/BadRequestException.kt
@@ -1,0 +1,20 @@
+package org.wine.productservice.wine.exception
+
+import org.wine.productservice.exception.BadRequestException
+
+class InvalidCategoryException private constructor(message: String) : BadRequestException(message) {
+    constructor(categoryIds: Set<Long>) : this("Invalid category ids: $categoryIds")
+}
+
+class InvalidRegionException private constructor(message: String) : BadRequestException(message) {
+    constructor(regionId: Long) : this("Invalid region id: $regionId")
+}
+
+object WineValidationMessages {
+    const val NAME_BLANK = "Name cannot be blank"
+    const val NAME_LENGTH = "Name must be between 2 and 100 characters long"
+    const val DESCRIPTION_BLANK = "Description cannot be blank"
+    const val DESCRIPTION_LENGTH = "Description must be at most 5000 characters long"
+}
+
+class InvalidRequestException(message: String) : BadRequestException(message)

--- a/product-service/src/main/resources/application-local.yml
+++ b/product-service/src/main/resources/application-local.yml
@@ -17,3 +17,10 @@ logging:
     org.springframework: DEBUG
     org.wine: DEBUG
 
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operationsSorter: method
+  override-with-generic-response: false


### PR DESCRIPTION
## 1. openapi 추가
implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
    implementation 'org.springdoc:springdoc-openapi-kotlin:1.7.0'
    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
    implementation 'org.springdoc:springdoc-openapi-starter-common:2.2.0'
- local에서만 동작하도록 설정.

## 2. Exception 수정.
- Valid check 관련해서는 const로 정리하고 NotFound와 Invalid 분류

## * 기타 수정
- fix: @field:를 붙이지 않으면 validation이 동작하지 않아서 추가.
- chore: 사용하지 않는 endpoint 삭제(GET wines/v1/test)